### PR TITLE
DX-2840 Update default `api-spec-path` input value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   api-spec-path: 
     description: The destination of the API Specification to generate a client from
     required: false
-    default: ./remote/bandwidth.json
+    default: ./remote/bandwidth.yml
   language: 
     description: The generator name (language) (`-g`) argument for the openapi-generator-cli
     required: true


### PR DESCRIPTION
Our api-specs repo now outputs the spec in `.yml` format